### PR TITLE
Fix character selection causing immediate pause

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -460,7 +460,9 @@ class GameScene extends Phaser.Scene {
             }).setOrigin(0.5, 0.5);
             
             // Click handler
-            card.on('pointerdown', () => {
+            card.on('pointerdown', (event) => {
+                // Prevent the click from bubbling to the global click handler
+                event.stopPropagation();
                 this.selectCharacter(character);
             });
             


### PR DESCRIPTION
Fixes bug where clicking a character with the mouse would start the game but immediately pause it. Prevents mouse click event bubbling from character cards to global click handler.